### PR TITLE
Update SuperNintendoEntertainmentSystem.json

### DIFF
--- a/platforms/SuperNintendoEntertainmentSystem.json
+++ b/platforms/SuperNintendoEntertainmentSystem.json
@@ -5,7 +5,7 @@
     "name": "Super Nintendo Entertainment System",
     "shortname": "snes",
     "description": null,
-    "acceptedFilenameRegex": "^(?!(?:\\._|\\.).*).*$",
+    "acceptedFilenameRegex": "^(?!(?:\\._|\\.).*).*(?<!bml)$",
     "scraperSourceList": [
       "LIBRETRO:Nintendo - Super Nintendo Entertainment System",
       "DSESS:BOX_ART:TAGS(scraperKeyword):https://thegamesdb.net/search.php?name=%7BscraperKeyword%7D&platform_id%5B%5D=6&dsess_selector=img.card-img-top&dsess_attribute=src&dsess_replacer=images%5C%2F.%2A%5C%2Fboxart&dsess_replacer_value=images%2Foriginal%2Fboxart",


### PR DESCRIPTION
Update SNES so `*bml` files are not added to gamelist. To launch msu1 games you can simply launch the patched `gamename.sfc`. As noted [here](https://docs.libretro.com/library/snes9x/#msu-1-support)) emulator should auto read the `manifest.bml` file. This avoids clutter if user has multiple msu1 games.