### PR TITLE
Add new Azahar app ID

### DIFF
--- a/platforms/Nintendo3DS.json
+++ b/platforms/Nintendo3DS.json
@@ -24,11 +24,21 @@
   },
   "playerList": [
     {
-      "name": "3ds - azahar",
+      "name": "3ds - Azahar - Google Play",
       "uniqueId": "3ds.azahar",
       "description": "Supported extensions: cci, cxi, zcci, zcxi.",
       "acceptedFilenameRegex": "^(.*)\\.(?:cci|cxi|zcci|zcxi)$",
       "amStartArguments": "-n io.github.lime3ds.android/org.citra.citra_emu.activities.EmulationActivity\n -a android.intent.action.VIEW\n -d {file.uri}\n --activity-clear-task\n --activity-clear-top\n",
+      "killPackageProcesses": false,
+      "killPackageProcessesWarning": true,
+      "extra": ""
+    },
+    {
+      "name": "3ds - Azahar - Vanilla",
+      "uniqueId": "3ds.azahar.vanilla",
+      "description": "Supported extensions: cci, cxi, zcci, zcxi.",
+      "acceptedFilenameRegex": "^(.*)\\.(?:cci|cxi|zcci|zcxi)$",
+      "amStartArguments": "-n org.azahar_emu.azahar/org.citra.citra_emu.activities.EmulationActivity\n -a android.intent.action.VIEW\n -d {file.uri}\n --activity-clear-task\n --activity-clear-top\n",
       "killPackageProcesses": false,
       "killPackageProcessesWarning": true,
       "extra": ""


### PR DESCRIPTION
Azahar changed the app ID for the vanilla variant in the new release.
This pull request adds the new app ID as a new entry, and renames the original entry to reflect the fact that there are two different variants.