### PR TITLE
Add New Eden Nightly

### DIFF
--- a/platforms/NintendoSwitch.json
+++ b/platforms/NintendoSwitch.json
@@ -1,6 +1,6 @@
 {
   "databaseVersion": 14,
-  "revisionNumber": 21,
+  "revisionNumber": 22,
   "platform": {
     "name": "Nintendo Switch",
     "uniqueId": "switch",
@@ -77,6 +77,16 @@
       "description": "Supported extensions: nro, nso, nca, xci, nsp.",
       "acceptedFilenameRegex": "^(.*)\\.(?:nro|nso|nca|xci|nsp)$",
       "amStartArguments": "-n dev.eden.eden_nightly/org.yuzu.yuzu_emu.activities.EmulationActivity\n -a android.nfc.action.TECH_DISCOVERED\n -d {file.uri}",
+      "killPackageProcesses": false,
+      "killPackageProcessesWarning": false,
+      "extra": ""
+    },
+    {
+      "name": "switch - eden (Nightly New)",
+      "uniqueId": "switch.dev.eden.eden_emulator.nightly",
+      "description": "Supported extensions: nro, nso, nca, xci, nsp.",
+      "acceptedFilenameRegex": "^(.*)\\.(?:nro|nso|nca|xci|nsp)$",
+      "amStartArguments": "-n dev.eden.eden_emulator.nightly/org.yuzu.yuzu_emu.activities.EmulationActivity\n -a android.nfc.action.TECH_DISCOVERED\n -d {file.uri}",
       "killPackageProcesses": false,
       "killPackageProcessesWarning": false,
       "extra": ""

--- a/platforms/index.json
+++ b/platforms/index.json
@@ -461,7 +461,7 @@
       "platformName": "Nintendo Switch",
       "platformShortname": "switch",
       "platformUniqueId": "switch",
-      "revisionNumber": 21
+      "revisionNumber": 22
     },
     {
       "filename": "NintendoWii.json",


### PR DESCRIPTION
This adds the new nightly support from https://git.eden-emu.dev/eden-ci. Feel free to update the name as needed.